### PR TITLE
Implement broadcast templates and scheduling

### DIFF
--- a/admin/routes/stats.py
+++ b/admin/routes/stats.py
@@ -4,6 +4,8 @@ import os
 import logging
 import requests
 import datetime
+import threading
+import time
 
 stats_bp = Blueprint('stats', __name__, url_prefix='/stats')
 
@@ -29,6 +31,34 @@ def load_broadcast_history(history_path):
 def save_broadcast_history(history_path, history):
     with open(history_path, 'wb') as f:
         pickle.dump(history, f)
+
+def get_templates_path(user_base):
+    return os.path.join(user_base, 'broadcast_templates.pkl')
+
+def load_templates(path):
+    try:
+        with open(path, 'rb') as f:
+            return pickle.load(f)
+    except Exception:
+        return []
+
+def save_templates(path, templates):
+    with open(path, 'wb') as f:
+        pickle.dump(templates, f)
+
+def get_scheduled_path(user_base):
+    return os.path.join(user_base, 'scheduled_broadcasts.pkl')
+
+def load_scheduled(path):
+    try:
+        with open(path, 'rb') as f:
+            return pickle.load(f)
+    except Exception:
+        return []
+
+def save_scheduled(path, data):
+    with open(path, 'wb') as f:
+        pickle.dump(data, f)
 
 def load_accounts_by_group(path, session_userinfo=None):
     result = {}
@@ -73,6 +103,57 @@ def load_accounts_by_group(path, session_userinfo=None):
         if accs:
             result[groupname] = accs
     return result
+
+def send_broadcast(TG_TOKEN, sessions_path, history_path, text, usernames, name=''):
+    user_chatid_map = {}
+    if os.path.exists(sessions_path):
+        try:
+            with open(sessions_path, 'rb') as sf:
+                sess_data = pickle.load(sf)
+            for uid, info in sess_data.get('user_data', {}).items():
+                if info.get('username'):
+                    user_chatid_map[info['username'].lower()] = info.get('user_id')
+        except Exception as e:
+            logging.exception("Не удалось прочитать sessions.pkl: %s", e)
+
+    send_results = []
+    for uname in usernames:
+        chat_id = user_chatid_map.get(uname.lower())
+        if chat_id:
+            try:
+                send_url = f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage"
+                payload = {'chat_id': chat_id, 'text': text, 'parse_mode': 'Markdown'}
+                resp = requests.post(send_url, data=payload, timeout=10)
+                if resp.status_code != 200:
+                    try:
+                        desc = resp.json().get('description', '')
+                    except Exception:
+                        desc = ''
+                    send_results.append((uname, f"Error {resp.status_code}: {desc}"))
+                else:
+                    send_results.append((uname, 'OK'))
+            except Exception as e:
+                logging.exception("Ошибка отправки сообщ. %s", e)
+                send_results.append((uname, 'Exception'))
+        else:
+            send_results.append((uname, 'Нет chat_id (пользователь не писал боту?)'))
+
+    try:
+        history = load_broadcast_history(history_path)
+        history.append({
+            'dt': datetime.datetime.now().strftime('%d.%m.%Y %H:%M'),
+            'name': name,
+            'text': text,
+            'recipients': usernames,
+            'results': send_results
+        })
+        if len(history) > 50:
+            history = history[-50:]
+        save_broadcast_history(history_path, history)
+    except Exception as e:
+        logging.exception('Не удалось записать историю рассылок: %s', e)
+
+    return send_results
 
 @stats_bp.route('/', methods=['GET', 'POST'])
 def index():
@@ -128,66 +209,15 @@ def index():
             return redirect(url_for('stats.index'))
 
         selected = request.form.getlist('selected')
-        targets = []
-        for group_accounts in accounts_by_group.values():
-            for acc in group_accounts:
-                if acc['username'] in selected:
-                    targets.append(acc)
 
-        user_chatid_map = {}
-        if os.path.exists(sessions_path):
-            try:
-                with open(sessions_path, 'rb') as sf:
-                    sess_data = pickle.load(sf)
-                for uid, info in sess_data.get('user_data', {}).items():
-                    if info.get('username'):
-                        user_chatid_map[info['username'].lower()] = info.get('user_id')
-            except Exception as e:
-                logging.exception("Не удалось прочитать sessions.pkl: %s", e)
-
-        send_results = []
-        for acc in targets:
-            username = acc['username']
-            chat_id = user_chatid_map.get(username.lower())
-            if chat_id:
-                try:
-                    send_url = f"https://api.telegram.org/bot{TG_TOKEN}/sendMessage"
-                    payload = {
-                        'chat_id': chat_id,
-                        'text': message_text,
-                        'parse_mode': 'Markdown'
-                    }
-                    resp = requests.post(send_url, data=payload, timeout=10)
-                    if resp.status_code != 200:
-                        try:
-                            err_data = resp.json()
-                            desc = err_data.get('description', '')
-                        except Exception:
-                            desc = ''
-                        send_results.append((username, f"Error {resp.status_code}: {desc}"))
-                    else:
-                        send_results.append((username, 'OK'))
-                except Exception as e:
-                    logging.exception("Ошибка отправки сообщ. %s", e)
-                    send_results.append((username, 'Exception'))
-            else:
-                send_results.append((username, 'Нет chat_id (пользователь не писал боту?)'))
-
-        # --- Добавляем в историю рассылок ---
-        try:
-            history = load_broadcast_history(history_path)
-            history.append({
-                "dt": datetime.datetime.now().strftime('%d.%m.%Y %H:%M'),
-                "name": name,  # имя из формы
-                "text": message_text,
-                "recipients": [acc['username'] for acc in targets],
-                "results": send_results
-            })
-            if len(history) > 50:
-                history = history[-50:]
-            save_broadcast_history(history_path, history)
-        except Exception as e:
-            logging.exception("Не удалось записать историю рассылок: %s", e)
+        send_results = send_broadcast(
+            TG_TOKEN,
+            sessions_path,
+            history_path,
+            message_text,
+            selected,
+            name
+        )
 
         session['send_results'] = send_results
         session['selected_usernames'] = selected
@@ -207,5 +237,131 @@ def index():
         send_results=send_results,
         selected_usernames=selected_usernames,
         broadcast_history=broadcast_history,
-        name=name
+        name=name,
+        templates=load_templates(get_templates_path(user_base)),
+        scheduled=load_scheduled(get_scheduled_path(user_base))
     )
+
+
+@stats_bp.route('/template/create', methods=['POST'])
+def create_template():
+    user_base = get_user_base_dir()
+    if not user_base:
+        return redirect(url_for('stats.index'))
+    path = get_templates_path(user_base)
+    templates = load_templates(path)
+    name = request.form.get('tpl_name', '').strip()
+    text = request.form.get('tpl_text', '').strip()
+    if name and text:
+        templates.append({'name': name, 'text': text})
+        save_templates(path, templates)
+        flash('Шаблон сохранён', 'success')
+    else:
+        flash('Имя и текст шаблона обязательны', 'danger')
+    return redirect(url_for('stats.index'))
+
+
+@stats_bp.route('/template/edit/<int:idx>', methods=['POST'])
+def edit_template(idx):
+    user_base = get_user_base_dir()
+    if not user_base:
+        return redirect(url_for('stats.index'))
+    path = get_templates_path(user_base)
+    templates = load_templates(path)
+    if 0 <= idx < len(templates):
+        templates[idx]['name'] = request.form.get('tpl_name', templates[idx]['name']).strip()
+        templates[idx]['text'] = request.form.get('tpl_text', templates[idx]['text']).strip()
+        save_templates(path, templates)
+        flash('Шаблон обновлён', 'success')
+    return redirect(url_for('stats.index'))
+
+
+@stats_bp.route('/template/delete/<int:idx>', methods=['POST'])
+def delete_template(idx):
+    user_base = get_user_base_dir()
+    if not user_base:
+        return redirect(url_for('stats.index'))
+    path = get_templates_path(user_base)
+    templates = load_templates(path)
+    if 0 <= idx < len(templates):
+        templates.pop(idx)
+        save_templates(path, templates)
+        flash('Шаблон удалён', 'success')
+    return redirect(url_for('stats.index'))
+
+
+@stats_bp.route('/schedule', methods=['POST'])
+def schedule_broadcast():
+    user_base = get_user_base_dir()
+    if not user_base:
+        return redirect(url_for('stats.index'))
+    path = get_scheduled_path(user_base)
+    scheduled = load_scheduled(path)
+    text = request.form.get('message_text', '').strip()
+    name = request.form.get('name', '').strip()
+    send_date = request.form.get('send_date')
+    send_time = request.form.get('send_time')
+    usernames = request.form.getlist('selected')
+    if not text or not send_date or not send_time:
+        flash('Заполните все поля для отложенной рассылки', 'danger')
+        return redirect(url_for('stats.index'))
+    dt_str = f'{send_date} {send_time}'
+    try:
+        datetime.datetime.strptime(dt_str, '%Y-%m-%d %H:%M')
+    except ValueError:
+        flash('Неверный формат даты или времени', 'danger')
+        return redirect(url_for('stats.index'))
+    scheduled.append({'name': name, 'text': text, 'usernames': usernames, 'send_at': dt_str})
+    save_scheduled(path, scheduled)
+    flash('Рассылка запланирована', 'success')
+    return redirect(url_for('stats.index'))
+
+
+def _scheduled_worker():
+    while True:
+        try:
+            mentors_root = '/opt/mentors'
+            if os.path.isdir(mentors_root):
+                for user in os.listdir(mentors_root):
+                    user_base = os.path.join(mentors_root, user)
+                    sched_path = get_scheduled_path(user_base)
+                    if not os.path.exists(sched_path):
+                        continue
+                    try:
+                        tasks = load_scheduled(sched_path)
+                    except Exception:
+                        tasks = []
+                    if not tasks:
+                        continue
+                    env_path = os.path.join(user_base, '.env')
+                    TG_TOKEN = None
+                    try:
+                        with open(env_path, 'r') as env_file:
+                            for line in env_file:
+                                if line.strip().startswith('TG_TOKEN='):
+                                    TG_TOKEN = line.strip().split('=', 1)[1]
+                                    break
+                    except Exception:
+                        TG_TOKEN = None
+                    if not TG_TOKEN:
+                        continue
+                    sessions_path = os.path.join(user_base, 'sessions.pkl')
+                    history_path = get_broadcast_history_path(user_base)
+                    remaining = []
+                    now = datetime.datetime.now()
+                    for t in tasks:
+                        try:
+                            send_at = datetime.datetime.strptime(t['send_at'], '%Y-%m-%d %H:%M')
+                        except Exception:
+                            continue
+                        if now >= send_at:
+                            send_broadcast(TG_TOKEN, sessions_path, history_path, t['text'], t['usernames'], t.get('name',''))
+                        else:
+                            remaining.append(t)
+                    save_scheduled(sched_path, remaining)
+        except Exception:
+            logging.exception('Ошибка планировщика рассылок')
+        time.sleep(60)
+
+
+threading.Thread(target=_scheduled_worker, daemon=True).start()

--- a/admin/templates/stats.html
+++ b/admin/templates/stats.html
@@ -13,6 +13,21 @@
         <textarea id="message_text" name="message_text" class="form-control" rows="9"></textarea>
       </div>
       <div class="mb-3">
+        <label for="template_select" class="form-label">Шаблоны</label>
+        <div class="input-group">
+          <select id="template_select" class="form-select">
+            <option selected disabled value="">Выберите...</option>
+            {% for t in templates %}
+              <option value="{{ loop.index0 }}">{{ t.name }}</option>
+            {% endfor %}
+          </select>
+          <button type="button" class="btn btn-outline-secondary" id="load-template">Загрузить</button>
+          <button type="button" class="btn btn-outline-secondary" onclick="showSaveTemplate(false)">Сохранить</button>
+          <button type="button" class="btn btn-outline-secondary" onclick="showSaveTemplate(true)">Редактировать</button>
+          <button type="button" class="btn btn-outline-danger" id="delete-template">Удалить</button>
+        </div>
+      </div>
+      <div class="mb-3">
         <input class="form-check-input me-2" type="checkbox" id="select-all-global">
         <label class="form-check-label fw-bold" for="select-all-global">Отправить всем</label>
       </div>
@@ -61,6 +76,23 @@
         {% endfor %}
       </div>
       <button type="submit" class="btn btn-primary">Разослать</button>
+      <button type="button" class="btn btn-secondary ms-2" id="open-schedule">Запланировать</button>
+    </form>
+
+    <form method="post" action="{{ url_for('stats.schedule_broadcast') }}" id="schedule-form" class="mt-3" style="display:none;">
+      <input type="hidden" name="name">
+      <input type="hidden" name="message_text">
+      <div id="schedule-selected-container"></div>
+      <div class="mb-2">
+        <label class="form-label">Дата отправки</label>
+        <input type="date" name="send_date" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Время отправки</label>
+        <input type="time" name="send_time" class="form-control" required>
+      </div>
+      <button type="button" class="btn btn-success" id="schedule-submit">Создать задачу</button>
+      <button type="button" class="btn btn-link" id="cancel-schedule">Отмена</button>
     </form>
 
     {% if send_results %}
@@ -110,6 +142,24 @@
   </div>
   <div class="col-lg-4">
     <div class="sticky-top" style="top:1.5rem;">
+      <div class="card shadow-sm mb-3">
+        <div class="card-header fw-bold">Запланированные</div>
+        <div class="card-body" style="max-height:40vh; overflow-y:auto;">
+          {% if scheduled %}
+            <ul class="list-group list-group-flush">
+            {% for s in scheduled %}
+              <li class="list-group-item">
+                <div class="small text-muted">{{ s.send_at }}</div>
+                <div><b>{{ s.name|default('-') }}</b></div>
+                <div class="small">{{ s.text[:40] }}{% if s.text|length > 40 %}...{% endif %}</div>
+              </li>
+            {% endfor %}
+            </ul>
+          {% else %}
+            <span class="text-muted">Нет запланированных рассылок.</span>
+          {% endif %}
+        </div>
+      </div>
       <div class="card shadow-sm">
         <div class="card-header fw-bold">
           История рассылок
@@ -186,4 +236,88 @@
     </div>
   </div>
 {% endfor %}
+
+<div class="modal fade" id="templateModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="templateForm" method="post">
+        <div class="modal-header">
+          <h5 class="modal-title">Шаблон</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Закрыть"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Имя</label>
+            <input type="text" name="tpl_name" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Текст</label>
+            <textarea name="tpl_text" class="form-control" rows="6" required></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Отмена</button>
+          <button type="submit" class="btn btn-primary">Сохранить</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.getElementById('load-template').onclick = function(){
+    const idx = document.getElementById('template_select').value;
+    if(idx === '' || idx === null) return;
+    const tpl = {{ templates|tojson }}[idx];
+    document.getElementById('message_text').value = tpl.text;
+    document.getElementById('name').value = tpl.name;
+  };
+  document.getElementById('delete-template').onclick = function(){
+    const idx = document.getElementById('template_select').value;
+    if(idx=== ''||idx===null) return;
+    const f = document.createElement('form');
+    f.method='post';
+    f.action='{{ url_for('stats.delete_template', idx=0) }}'.replace('0', idx);
+    document.body.appendChild(f);
+    f.submit();
+  };
+  function showSaveTemplate(edit){
+    const modal = new bootstrap.Modal(document.getElementById('templateModal'));
+    const form = document.getElementById('templateForm');
+    form.action = edit ? '{{ url_for('stats.edit_template', idx=0) }}'.replace('0', document.getElementById('template_select').value||0)
+                       : '{{ url_for('stats.create_template') }}';
+    if(edit){
+      const idx = document.getElementById('template_select').value;
+      if(idx === '' || idx === null) return;
+      const tpl = {{ templates|tojson }}[idx];
+      form.tpl_name.value = tpl.name;
+      form.tpl_text.value = tpl.text;
+    }else{
+      form.tpl_name.value='';
+      form.tpl_text.value=document.getElementById('message_text').value;
+    }
+    modal.show();
+  }
+  document.getElementById('open-schedule').onclick = function(){
+    document.getElementById('schedule-form').style.display='block';
+  };
+  document.getElementById('cancel-schedule').onclick = function(){
+    document.getElementById('schedule-form').style.display='none';
+  };
+  document.getElementById('schedule-submit').onclick = function(){
+    const form = document.getElementById('schedule-form');
+    form.querySelector('input[name="name"]').value = document.getElementById('name').value;
+    form.querySelector('input[name="message_text"]').value = document.getElementById('message_text').value;
+    const cont = document.getElementById('schedule-selected-container');
+    cont.innerHTML='';
+    document.querySelectorAll('.user-checkbox:checked').forEach(cb=>{
+      const inp=document.createElement('input');
+      inp.type='hidden';
+      inp.name='selected';
+      inp.value=cb.value;
+      cont.appendChild(inp);
+    });
+    form.submit();
+  };
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add template and schedule helpers
- enable creation, editing, deletion of message templates
- allow scheduling broadcasts with date and time
- display scheduled tasks and use background worker

## Testing
- `python3 -m py_compile admin/routes/stats.py`

------
https://chatgpt.com/codex/tasks/task_e_68409170f4e48331b2faa1af1966ccde