### PR TITLE
Fix hardcoded mentor path

### DIFF
--- a/admin/routes/admin.py
+++ b/admin/routes/admin.py
@@ -79,7 +79,8 @@ def create_user():
 
     # Патчим ACCOUNTS_PATH в bot.py
     bot_path = os.path.join(user_dir, 'bot.py')
-    new_accounts_path = f"ACCOUNTS_PATH = '/opt/mentors/{login}/accounts.pkl'"
+    # В bot.py путь к accounts.pkl формируется относительно директории бота
+    new_accounts_path = "ACCOUNTS_PATH = os.path.join(BASE_DIR, 'accounts.pkl')"
     lines = []
     with open(bot_path, 'r') as f:
         for line in f:


### PR DESCRIPTION
## Summary
- use relative path for `ACCOUNTS_PATH` in mentor bot
- patch new user bot to use relative accounts path
- revert changes in `client1` bot

## Testing
- `find . -name '*.py' | xargs -I{} python -m py_compile {}`

------
https://chatgpt.com/codex/tasks/task_e_684095317ecc83318453fc813aedfb3b