### PR TITLE
Add admin client selection and user creation link

### DIFF
--- a/admin/app.py
+++ b/admin/app.py
@@ -6,6 +6,9 @@ from flask import (
 
 # во всех блюпринтах уже есть auth_bp, dashboard_bp, chats_bp и т.д.
 from routes import register_blueprints
+import json
+
+USERS_FILE_PATH = os.path.join(os.path.dirname(__file__), 'users.json')
 
 app = Flask(__name__)
 app.secret_key = os.environ.get("SECRET_KEY", "dev_secret_key")  # TODO: заменить в проде
@@ -14,6 +17,23 @@ app.secret_key = os.environ.get("SECRET_KEY", "dev_secret_key")  # TODO: зам�
 # Подключаем ВСЕ блюпринты
 # ------------------------------------------------------------------
 register_blueprints(app)
+
+
+@app.context_processor
+def inject_globals():
+    user = session.get('user', {})
+    is_admin = user.get('role') == 'admin'
+    selected_client = session.get('selected_client', '') if is_admin else ''
+    clients = []
+    if is_admin:
+        try:
+            with open(USERS_FILE_PATH, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            clients = [u for u, info in data.items() if info.get('role') == 'user']
+        except Exception:
+            pass
+    any_unread = any(session.get('unread', {}).values())
+    return dict(any_unread=any_unread, is_admin=is_admin, admin_clients=clients, selected_client=selected_client)
 
 # ------------------------------------------------------------------
 # Разрешённые маршруты без авторизации

--- a/admin/routes/accounts.py
+++ b/admin/routes/accounts.py
@@ -1,34 +1,49 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, jsonify, send_file
 import os
 import pickle
+from .helpers import current_client_login
 
 accounts_bp = Blueprint('accounts', __name__, url_prefix='/accounts')
 
 def get_user_dir():
-    return os.path.join('/opt/mentors', session['user']['name'])
+    login = current_client_login()
+    if not login:
+        return ''
+    return os.path.join('/opt/mentors', login)
 
 def get_accounts_file():
-    return os.path.join(get_user_dir(), 'accounts.pkl')
+    user_dir = get_user_dir()
+    if not user_dir:
+        return ''
+    return os.path.join(user_dir, 'accounts.pkl')
 
 def get_sessions_file():
-    return os.path.join(get_user_dir(), 'sessions.pkl')
+    user_dir = get_user_dir()
+    if not user_dir:
+        return ''
+    return os.path.join(user_dir, 'sessions.pkl')
 
 def load_accounts():
     path = get_accounts_file()
-    if not os.path.exists(path):
+    if not path or not os.path.exists(path):
         data = {"allow_all": False, "accounts": [], "groups": {}}
-        save_accounts(data)
+        if path:
+            save_accounts(data)
         return data
     with open(path, 'rb') as f:
         return pickle.load(f)
 
 def save_accounts(data):
     path = get_accounts_file()
+    if not path:
+        return
     with open(path, 'wb') as f:
         pickle.dump(data, f)
 
 def sync_sessions_user(user):
     sessions_path = get_sessions_file()
+    if not sessions_path:
+        return
     if os.path.exists(sessions_path):
         with open(sessions_path, "rb") as f:
             data = pickle.load(f)
@@ -50,6 +65,8 @@ def sync_sessions_user(user):
 
 def remove_sessions_user(username):
     sessions_path = get_sessions_file()
+    if not sessions_path:
+        return
     if not os.path.exists(sessions_path):
         return
     with open(sessions_path, "rb") as f:
@@ -62,7 +79,7 @@ def remove_sessions_user(username):
 
 def fetch_names_from_sessions(usernames):
     sessions_path = get_sessions_file()
-    if not os.path.exists(sessions_path):
+    if not sessions_path or not os.path.exists(sessions_path):
         return {}
     with open(sessions_path,'rb') as f:
         data = pickle.load(f)
@@ -179,8 +196,12 @@ def export_data():
         for u in data['accounts']:
             name = f" {u.get('first_name','')} {u.get('last_name','')}".strip()
             out.append(f"{u['username']}{name}")
-    path=os.path.join(get_user_dir(),"export.txt")
-    with open(path,"w") as f: f.write("\n".join(out))
+    user_dir = get_user_dir()
+    if not user_dir:
+        return jsonify({'error':'no user selected'}), 400
+    path=os.path.join(user_dir,"export.txt")
+    with open(path,"w") as f:
+        f.write("\n".join(out))
     return send_file(path,as_attachment=True,download_name="export.txt")
 
 @accounts_bp.route('/user_action', methods=['POST'])

--- a/admin/routes/admin.py
+++ b/admin/routes/admin.py
@@ -42,6 +42,14 @@ def index():
     users = load_users()
     return render_template('admin.html', users=users)
 
+# ========== Выбор клиента для просмотра ==========
+@admin_bp.route('/select_client', methods=['POST'])
+@login_required(role='admin')
+def select_client():
+    client = request.form.get('client', '').strip()
+    session['selected_client'] = client
+    return redirect(request.referrer or url_for('dashboard.index'))
+
 # ========== Создание пользователя/бота ==========
 @admin_bp.route('/create_user', methods=['POST'])
 @login_required(role='admin')

--- a/admin/routes/auth.py
+++ b/admin/routes/auth.py
@@ -31,6 +31,8 @@ def login():
         user = users.get(username)
         if user and user['password'] == password:
             session['user'] = {'name': username, 'role': user['role']}
+            if user['role'] == 'admin':
+                session['selected_client'] = ''
             return redirect(url_for('dashboard.index'))
         flash('Неверный логин/пароль')
     return render_template('login.html', title='Вход')

--- a/admin/routes/chats.py
+++ b/admin/routes/chats.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request, session
+from .helpers import current_client_login
 import os
 import pickle
 from collections import defaultdict
@@ -151,7 +152,7 @@ def group_has_unread(accs: list, unread_status: dict) -> bool:
 
 @chats_bp.route('/', methods=['GET'])
 def index():
-    client_login = session.get('user', {}).get('name', '')
+    client_login = current_client_login()
 
     groups, sessions = merge_accounts_and_sessions(client_login)
     unread = unread_map()

--- a/admin/routes/dashboard.py
+++ b/admin/routes/dashboard.py
@@ -3,6 +3,7 @@ import pickle
 from datetime import datetime, timedelta
 from collections import Counter
 from flask import Blueprint, render_template, session, request, current_app
+from .helpers import current_client_login
 from .chats import get_sessions_file
 
 dashboard_bp = Blueprint('dashboard', __name__, url_prefix='/dashboard')
@@ -21,7 +22,7 @@ def _safe_date(val: str, default):
 
 @dashboard_bp.route('/', methods=['GET'])
 def index():
-    client_login = session.get('user', {}).get('name')
+    client_login = current_client_login()
     if not client_login:
         return render_template(
             'dashboard.html',

--- a/admin/routes/files.py
+++ b/admin/routes/files.py
@@ -1,14 +1,21 @@
 import os
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session, send_from_directory
+from .helpers import current_client_login
 
 files_bp = Blueprint('files', __name__, url_prefix='/files')
 
 def get_user_materials_dir():
-    return os.path.join('/opt/mentors', session['user']['name'], 'materials')
+    login = current_client_login()
+    if not login:
+        return ''
+    return os.path.join('/opt/mentors', login, 'materials')
 
 @files_bp.route('/', methods=['GET', 'POST'])
 def index():
     user_folder = get_user_materials_dir()
+    if not user_folder:
+        flash('Не выбран клиент', 'warning')
+        return redirect(url_for('dashboard.index'))
     os.makedirs(user_folder, exist_ok=True)
 
     # Загрузка одного или нескольких файлов
@@ -38,6 +45,9 @@ def index():
 @files_bp.route('/edit/<filename>', methods=['GET', 'POST'])
 def edit_file(filename):
     user_folder = get_user_materials_dir()
+    if not user_folder:
+        flash('Не выбран клиент', 'warning')
+        return redirect(url_for('files.index'))
     filepath = os.path.join(user_folder, filename)
     if not os.path.abspath(filepath).startswith(os.path.abspath(user_folder)):
         flash('Нельзя редактировать этот файл.', 'danger')
@@ -68,6 +78,9 @@ def edit_file(filename):
 @files_bp.route('/delete/<filename>', methods=['POST'])
 def delete_file(filename):
     user_folder = get_user_materials_dir()
+    if not user_folder:
+        flash('Не выбран клиент', 'warning')
+        return redirect(url_for('files.index'))
     filepath = os.path.join(user_folder, filename)
     if not os.path.abspath(filepath).startswith(os.path.abspath(user_folder)):
         flash('Нельзя удалить этот файл.', 'danger')
@@ -83,4 +96,7 @@ def delete_file(filename):
 @files_bp.route('/download/<filename>')
 def download_file(filename):
     user_folder = get_user_materials_dir()
+    if not user_folder:
+        flash('Не выбран клиент', 'warning')
+        return redirect(url_for('files.index'))
     return send_from_directory(user_folder, filename, as_attachment=True)

--- a/admin/routes/helpers.py
+++ b/admin/routes/helpers.py
@@ -1,0 +1,8 @@
+from flask import session
+
+def current_client_login() -> str:
+    user = session.get('user', {})
+    if user.get('role') == 'admin':
+        return session.get('selected_client', '')
+    return user.get('name', '')
+

--- a/admin/routes/stats.py
+++ b/admin/routes/stats.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, session
+from .helpers import current_client_login
 import pickle
 import os
 import logging
@@ -10,13 +11,10 @@ import time
 stats_bp = Blueprint('stats', __name__, url_prefix='/stats')
 
 def get_user_base_dir():
-    user_session = session.get('user')
-    if not user_session:
+    login = current_client_login()
+    if not login:
         return None
-    username = user_session.get('name')
-    if not username:
-        return None
-    return os.path.join('/opt/mentors', username)
+    return os.path.join('/opt/mentors', login)
 
 def get_broadcast_history_path(user_base):
     return os.path.join(user_base, 'broadcast_history.pkl')
@@ -163,7 +161,10 @@ def index():
         return redirect(url_for('auth.login'))
 
     user_base = get_user_base_dir()
-    if not user_base or not os.path.isdir(user_base):
+    if not user_base:
+        flash('Не выбран клиент', 'warning')
+        return redirect(url_for('dashboard.index'))
+    if not os.path.isdir(user_base):
         flash('Каталог пользователя не найден', 'danger')
         return redirect(url_for('dashboard.index'))
 

--- a/admin/templates/admin.html
+++ b/admin/templates/admin.html
@@ -8,4 +8,11 @@
     <input type="text" name="token" placeholder="Telegram TG_TOKEN" required>
     <button type="submit">Создать</button>
 </form>
+
+<h3 class="mt-4">Существующие пользователи</h3>
+<ul>
+{% for login, info in users.items() if info.role == 'user' %}
+    <li>{{ login }}</li>
+{% endfor %}
+</ul>
 {% endblock %}

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -58,6 +58,21 @@
                     Рассылка
                 </a>
             </li>
+            {% if is_admin %}
+            <li class="nav-item">
+                <form method="post" action="{{ url_for('admin.select_client') }}" class="d-flex">
+                    <select name="client" class="form-select form-select-sm me-2" onchange="this.form.submit()">
+                        <option value="">Клиент</option>
+                        {% for c in admin_clients %}
+                        <option value="{{ c }}" {% if selected_client==c %}selected{% endif %}>{{ c }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link {% if request.endpoint.startswith('admin.') %}fw-bold{% endif %}" href="{{ url_for('admin.index') }}">Добавить</a>
+            </li>
+            {% endif %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('auth.logout') }}">Выход</a>
             </li>


### PR DESCRIPTION
## Summary
- enable choosing client info when logged as admin
- add helper to determine current client
- add client selection dropdown and "Добавить" link to the main menu
- ensure admin login clears selected client
- add route to change current client

## Testing
- `python -m py_compile admin/routes/*.py admin/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68409f14ed6c83319b08bc5f419f7511